### PR TITLE
Revert d797cc888fdd358f40be1b53469ddcfb40131f10

### DIFF
--- a/VATRP/AppDelegate.m
+++ b/VATRP/AppDelegate.m
@@ -47,14 +47,12 @@
                                              selector:@selector(registrationUpdateEvent:)
                                                  name:kLinphoneRegistrationUpdate
                                                object:nil];
-#ifdef DEBUG
-    NSLog(@"Debug: No crashes will be reported");
-#else
+    
+    
     [[BITHockeyManager sharedHockeyManager] configureWithIdentifier:@"b7b28171bab92ce345aac7d54f435020"];
     [[BITHockeyManager sharedHockeyManager].crashManager setAutoSubmitCrashReport: YES];
     [[BITHockeyManager sharedHockeyManager] startManager];
-#endif
-
+    
     linphone_core_set_log_level(ORTP_DEBUG);
     linphone_core_set_log_handler((OrtpLogFunc)linphone_iphone_log_handler);
 }


### PR DESCRIPTION
Reverts VTCSecureLLC/ace-mac#67
We are still in debug mode. 
xctool -project ACE.xcodeproj \
       -scheme VATRP \
       -sdk macosx \
       -configuration Debug \
       -derivedDataPath build/derived \
       archive \
       -archivePath $XCARCHIVE \
       CODE_SIGN_IDENTITY="$CODE_SIGN_APPLICATION"
       #PROVISIONING_PROFILE="$PROVISIONING_PROFILE"
