### PR TITLE
fix linking issue in executable binary

### DIFF
--- a/ACE.xcodeproj/project.pbxproj
+++ b/ACE.xcodeproj/project.pbxproj
@@ -1811,8 +1811,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(SRCROOT)/VATRP/linphonesdk/libs",
 					"$(PROJECT_DIR)/VATRP/linphonesdk/libs",
-					"$(PROJECT_DIR)/OUTPUT/lib",
-					"$(PROJECT_DIR)/OUTPUT/lib/mediastreamer/plugins",
 					"$(PROJECT_DIR)/WORK/Build/linphone_package/linphone-sdk-tmp/lib",
 					"$(PROJECT_DIR)/WORK/Build/linphone_package/linphone-sdk-tmp/lib/mediastreamer/plugins",
 				);
@@ -1845,8 +1843,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(SRCROOT)/VATRP/linphonesdk/libs",
 					"$(PROJECT_DIR)/VATRP/linphonesdk/libs",
-					"$(PROJECT_DIR)/OUTPUT/lib",
-					"$(PROJECT_DIR)/OUTPUT/lib/mediastreamer/plugins",
 					"$(PROJECT_DIR)/WORK/Build/linphone_package/linphone-sdk-tmp/lib",
 					"$(PROJECT_DIR)/WORK/Build/linphone_package/linphone-sdk-tmp/lib/mediastreamer/plugins",
 				);
@@ -1875,7 +1871,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/OUTPUT/lib",
 					"$(PROJECT_DIR)/WORK/Build/linphone_package/linphone-sdk-tmp/lib",
 					"$(PROJECT_DIR)/WORK/Build/linphone_package/linphone-sdk-tmp/lib/mediastreamer/plugins",
 				);
@@ -1897,7 +1892,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/OUTPUT/lib",
 					"$(PROJECT_DIR)/WORK/Build/linphone_package/linphone-sdk-tmp/lib",
 					"$(PROJECT_DIR)/WORK/Build/linphone_package/linphone-sdk-tmp/lib/mediastreamer/plugins",
 				);


### PR DESCRIPTION
- don't use output directory in search path
