### PR TITLE
VATRP-842 - Mac Video Pause in place

### DIFF
--- a/VATRP/Home/Video/CallControllersView.m
+++ b/VATRP/Home/Video/CallControllersView.m
@@ -79,9 +79,12 @@
     
     if (isSendingVideo) {
         [self onVideoOn];
+        [self.buttonVideo.layer setBackgroundColor:[NSColor colorWithRed:92.0/255.0 green:117.0/255.0 blue:132.0/255.0 alpha:0.8].CGColor];
     } else {
         [self onVideoOff];
+        [self.buttonVideo.layer setBackgroundColor:[NSColor colorWithRed:182.0/255.0 green:60.0/255.0 blue:60.0/255.0 alpha:0.8].CGColor];
     }
+    [self.videoProgressIndicator stopAnimation:self];
 }
 
 - (IBAction)onButtonMute:(id)sender {
@@ -272,9 +275,10 @@
         callAppData->videoRequested =
         TRUE; /* will be used later to notify user if video was not activated because of the linphone core*/
         LinphoneCallParams *call_params = linphone_call_params_copy(linphone_call_get_current_params(call));
-        linphone_call_params_enable_video(call_params, TRUE);
-        linphone_core_update_call(lc, call, call_params);
+        linphone_call_enable_camera(call, TRUE);
+        linphone_core_update_call(lc, call, NULL);
         linphone_call_params_destroy(call_params);
+        
     } else {
         NSString* linphoneVersion = [NSString stringWithUTF8String:linphone_core_get_version()];
         NSLog(@"Cannot toggle video button, because no current call. LinphoneVersion: %@", linphoneVersion);
@@ -288,9 +292,14 @@
         return;
     
     if (call) {
+        // ToDo VATRP-842: Setting a static image, but until the static image is working in linphone we are currently seeing a black image.
+        //    The choice is this or a no webcam image. For testing, using no webcam image.
+//        NSString *pathToImageString = [[NSBundle mainBundle] pathForResource:@"contacts" ofType:@"png"];
+//        const char *pathToImage = [pathToImageString UTF8String];
         LinphoneCallParams *call_params = linphone_call_params_copy(linphone_call_get_current_params(call));
-        linphone_call_params_enable_video(call_params, FALSE);
-        linphone_core_update_call(lc, call, call_params);
+//        linphone_core_set_static_picture(lc, pathToImage);
+        linphone_call_enable_camera(call, FALSE);
+        linphone_core_update_call(lc, call, NULL);
         linphone_call_params_destroy(call_params);
     } else {
         NSString* linphoneVersion = [NSString stringWithUTF8String:linphone_core_get_version()];


### PR DESCRIPTION
Video pause now causes static image. Until the static image for linphone is working properly our choices are a black screen or the provided 'no webcam' image. Commented out the static image code so that the no webcam image can be used for testing, otherwise it shows a black image. Note - this mimics the iOS solution and does not have a 'frozen' image.
