### PR TITLE
VATRP-1012: Fixing another unfriendly message ('Unauthorized')

### DIFF
--- a/VATRP/Login/LoginViewController.m
+++ b/VATRP/Login/LoginViewController.m
@@ -191,7 +191,7 @@
         case LinphoneRegistrationFailed: {
             NSAlert *alert = [[NSAlert alloc]init];
             [alert addButtonWithTitle:@"OK"];
-            if ([message isEqualToString:@"Forbidden"])
+            if ([message isEqualToString:@"Forbidden"] || [message isEqualToString:@"Unauthorized"])
             {
                 [alert setMessageText:@"Either the user name or the password is incorrect. Please enter a valid user name and password."];
             }


### PR DESCRIPTION
Shows the same message now that we used to get rid of Forbidden
