### PR TITLE
VATRP-2204: verifying initial settings (some for start) are displayed…

### DIFF
--- a/VATRP/AppDelegate.m
+++ b/VATRP/AppDelegate.m
@@ -16,6 +16,7 @@
 #import "ChatService.h"
 #import <HockeySDK/HockeySDK.h>
 #import "LinphoneLocationManager.h"
+#import "SettingsHandler.h"
 
 @interface AppDelegate () {
     VideoCallWindowController *videoCallWindowController;
@@ -33,6 +34,8 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     // Insert code here to initialize your application
+    // Initialize settings on launch if they have not been. 
+    [SettingsHandler.settingsHandler initializeUserDefaults:false];
     
     [AccountsService sharedInstance];
     [CallLogService sharedInstance];

--- a/VATRP/Login/LoginViewController.m
+++ b/VATRP/Login/LoginViewController.m
@@ -341,18 +341,26 @@
 - (void)registrationUpdate:(LinphoneRegistrationState)state message:(NSString*)message {
     switch (state) {
         case LinphoneRegistrationOk: {
-            [[AccountsService sharedInstance] addAccountWithUsername:loginAccount.username
-                                                              UserID:loginAccount.userID
-                                                            Password:loginAccount.password
-                                                              Domain:loginAccount.domain
-                                                           Transport:loginAccount.transport
-                                                                Port:loginAccount.port
-                                                           isDefault:YES];
+//            if (loginAccount == nil)
+//            {
+                // ToDo - this needs a better fix. On launch, even auto-login is off, the last user is still being registered.
+                //   need to figure out where this is happening and prevent it.
+                //  for now, if the loginAccount is nil, then we need to figure out what account was just registered.
+            // NOTE - deal with this after 2-4 push
+//                const char* userName = linphone_core_get_identity([LinphoneManager getLc]);
+                
+//            }
+                [[AccountsService sharedInstance] addAccountWithUsername:loginAccount.username
+                                                                  UserID:loginAccount.userID
+                                                                Password:loginAccount.password
+                                                                  Domain:loginAccount.domain
+                                                               Transport:loginAccount.transport
+                                                                    Port:loginAccount.port
+                                                               isDefault:YES];
             
-            [[AppDelegate sharedInstance] showTabWindow];
-            [[AppDelegate sharedInstance].loginWindowController close];
-            [AppDelegate sharedInstance].loginWindowController = nil;
-            
+                [[AppDelegate sharedInstance] showTabWindow];
+                [[AppDelegate sharedInstance].loginWindowController close];
+                [AppDelegate sharedInstance].loginWindowController = nil;
             break;
         }
         case LinphoneRegistrationNone:

--- a/VATRP/Services/Settings/SettingsConstants.m
+++ b/VATRP/Services/Settings/SettingsConstants.m
@@ -14,7 +14,7 @@
 // AV Settings
 NSString *const MUTE_SPEAKER = @"SPEAKER_MUTE";
 NSString *const MUTE_MICROPHONE = @"MICROPHONE_MUTE";
-NSString *const ENABLE_ECHO_CANCELLATION = @"ECHO_CANCEL";
+NSString *const ENABLE_ECHO_CANCELLATION = @"enable_echo_cancellation";
 NSString *const VIDEO_SHOW_SELF_VIEW = @"VIDEO_SHOW_SELF_VIEW";
 NSString *const VIDEO_SHOW_PREVIEW = @"VIDEO_SHOW_PREVIEW";
 

--- a/VATRP/Services/Settings/SettingsHandler.h
+++ b/VATRP/Services/Settings/SettingsHandler.h
@@ -48,7 +48,8 @@
 @property(weak,nonatomic)id<InCallPreferencesHandlerDelegate> inCallPreferencessHandlerDelegate;
 @property(weak,nonatomic)id<PreferencesHandlerDelegate> preferencessHandlerDelegate;
 
--(void)initializeUserDefaults;
+// Bool force provided for debugging, and to reset settings when needed.
+-(void)initializeUserDefaults:(bool)force;
 
 
 #pragma mark items for inCallSettingsDelegate - setting from call window to settings dialog

--- a/VATRP/Services/Settings/SettingsHandler.m
+++ b/VATRP/Services/Settings/SettingsHandler.m
@@ -26,119 +26,133 @@
 }
 
 // initialization of user settings
--(void)initializeUserDefaults
+-(void)initializeUserDefaults:(bool)force
 {
     // "{\"version\":1,\"expiration_time\":3600,\"configuration_auth_password\":\"\",\"configuration_auth_expiration\":-1,\"sip_registration_maximum_threshold\":10,\"sip_register_usernames\":[],\"sip_auth_username\":\"\",\"sip_auth_password\":\"\",\"sip_register_domain\":\"acetest-registrar.vatrp.net\",\"sip_register_port\":25060,\"sip_register_transport\":\"tcp\",\"enable_echo_cancellation\":true,\"enable_video\":true,\"enable_rtt\":true,\"enable_adaptive_rate\":true,\"enabled_codecs\":[\"H.264\",\"H.263\",\"VP8\",\"G.722\",\"G.711\"],\"bwLimit\":\"high-fps\",\"upload_bandwidth\":660,\"download_bandwidth\":660,\"enable_stun\":false,\"stun_server\":\"\",\"enable_ice\":false,\"logging\":\"info\",\"sip_mwi_uri\":\"\",\"sip_videomail_uri\":\"\",\"video_resolution_maximum\":\"cif\"}"
 
     
     // convert these over to use the generic methods for app versus user settings when there is a chance
     
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"version"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"version"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setInteger:1 forKey:@"version"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"expiration_time"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"expiration_time"] == nil)
     {
-        [[NSUserDefaults standardUserDefaults] setInteger:3600 forKey:@"expiration_time" ];
+        [[NSUserDefaults standardUserDefaults] setInteger:280 forKey:@"expiration_time" ];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"version"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"configuration_auth_password"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:@"configuration_auth_password"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"version"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"configuration_auth_expiration"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setInteger:-1 forKey:@"configuration_auth_expiration"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"sip_registration_maximum_threshold"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"sip_registration_maximum_threshold"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setInteger:10 forKey:@"sip_registration_maximum_threshold"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"sip_register_usernames"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"sip_register_usernames"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:[[NSArray alloc]init ] forKey:@"sip_register_usernames"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"sip_auth_username"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"sip_auth_username"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:@"sip_auth_username"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"sip_auth_password"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"sip_auth_password"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:@"sip_auth_password"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"sip_register_domain"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"sip_register_domain"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"acetest-registrar.vatrp.net" forKey:@"sip_register_domain"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"sip_register_port"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"sip_register_port"] == nil)
     {
-        [[NSUserDefaults standardUserDefaults] setInteger:5060 forKey:@"sip_register_port"];
+        [[NSUserDefaults standardUserDefaults] setInteger:25060 forKey:@"sip_register_port"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"sip_register_transport"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"sip_register_transport"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"tcp" forKey:@"sip_register_transport"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"enable_echo_cancellation"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"enable_echo_cancellation"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"true" forKey:@"enable_echo_cancellation"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"enable_video_preference"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"enable_video_preference"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"true" forKey:@"enable_video_preference"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"kREAL_TIME_TEXT_ENABLED"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"kREAL_TIME_TEXT_ENABLED"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"true" forKey:@"kREAL_TIME_TEXT_ENABLED"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"enable_adaptive_rate_control"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"enable_adaptive_rate_control"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"true" forKey:@"enable_adaptive_rate_control"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"enabled_codecs"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"enabled_codecs"] == nil)
     {
         // enabled_codecs\":[\"H.264\",\"H.263\",\"VP8\",\"G.722\",\"G.711\"]
         NSArray *enabledCodecs = @[@"H.264", @"H.263", @"VP8", @"G.722", @"G.711"];
         [[NSUserDefaults standardUserDefaults] setObject:enabledCodecs forKey:@"enabled_codecs"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"bwLimit"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"bwLimit"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"high-fps" forKey:@"bwLimit"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"upload_bandwidth"] == nil)
+    if (force ||[[NSUserDefaults standardUserDefaults]objectForKey:@"upload_bandwidth"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setInteger:660 forKey:@"upload_bandwidth" ];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"download_bandwidth"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"download_bandwidth"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setInteger:660 forKey:@"download_bandwidth" ];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"stun_preference"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"stun_preference"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"false" forKey:@"stun_preference"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"stun_url_preference"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"stun_url_preference"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"acetest-regstrar.vatrp.net" forKey:@"stun_url_preference"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"ice_preference"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"ice_preference"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"false" forKey:@"ice_preference"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"logging"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"logging"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"info" forKey:@"logging"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"sip_mwi_uri"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"sip_mwi_uri"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:@"sip_mwi_uri"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"sip_videomail_uri"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"sip_videomail_uri"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:@"sip_videomail_uri"];
     }
-    if ([[NSUserDefaults standardUserDefaults]objectForKey:@"video_preferred_size_preference"] == nil)
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"video_preferred_size_preference"] == nil)
     {
         [[NSUserDefaults standardUserDefaults] setObject:@"cif" forKey:@"video_preferred_size_preference"];
     }
+
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:MUTE_MICROPHONE] == nil)
+    {
+        [self setUserSettingBool:MUTE_MICROPHONE withValue:true];
+    }
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:MUTE_SPEAKER] == nil)
+    {
+        [self setUserSettingBool:MUTE_SPEAKER withValue:true];
+    }
+    if (force || [[NSUserDefaults standardUserDefaults]objectForKey:VIDEO_SHOW_SELF_VIEW] == nil)
+    {
+        [self setUserSettingBool:VIDEO_SHOW_SELF_VIEW withValue:true];
+    }
+
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 

--- a/VATRP/Services/SettingsService.m
+++ b/VATRP/Services/SettingsService.m
@@ -212,7 +212,8 @@ extern void linphone_iphone_log_handler(int lev, const char *fmt, va_list args);
     if (enable) {
         linphone_core_set_firewall_policy(lc, LinphonePolicyUseIce);
     } else {
-        [SettingsService setStun:[[NSUserDefaults standardUserDefaults] boolForKey:@"stun_preference"]];
+        linphone_core_set_firewall_policy(lc, LinphonePolicyNoFirewall);
+        [SettingsService setStun:[[NSUserDefaults standardUserDefaults] boolForKey:@"ice_preference"]];
     }
 }
 
@@ -222,7 +223,8 @@ extern void linphone_iphone_log_handler(int lev, const char *fmt, va_list args);
     if (enable) {
         linphone_core_set_firewall_policy(lc, LinphonePolicyUseUpnp);
     } else {
-        [self setICE:[[NSUserDefaults standardUserDefaults] boolForKey:@"ice_preference"]];
+        linphone_core_set_firewall_policy(lc, LinphonePolicyNoFirewall);
+        [self setICE:[[NSUserDefaults standardUserDefaults] boolForKey:@"upnp_preference"]];
     }
 }
 


### PR DESCRIPTION
… in settings dialog, that settings are what we need for defaults. Added comment in loginviewcontroller for work that needs to be done. Added bool for devel to use to force reset initial settings. may also be used ultimately instead of blowing away the preferences, once we have all settings stored properly.
