### PR TITLE
VATRP-2274: self view setting fix.

### DIFF
--- a/VATRP/Services/Settings/SettingsHandler.m
+++ b/VATRP/Services/Settings/SettingsHandler.m
@@ -213,7 +213,7 @@
 
 
 // TODO: not sure these need delegate methods - we may be able to just handle the settings here directly?
--(void)setShowSelfPreview:(bool)show
+-(void)setShowSelfView:(bool)show
 {
     // does call window respond to this, or do we just show/hide?
     [self setUserSettingBool:VIDEO_SHOW_SELF_VIEW withValue:show];


### PR DESCRIPTION
header had method renamed, implementation did not.
