### PR TITLE
VATRP-2871: removing observers properly when items are deallocated. C…

### DIFF
--- a/VATRP/LinphoneManager/LinphoneManager.m
+++ b/VATRP/LinphoneManager/LinphoneManager.m
@@ -260,10 +260,7 @@ NSString *const kLinphoneInternalChatDBFilename = @"linphone_chats.db";
     //	if (lStatus) {
     //		LOGE(@"cannot un register route change handler [%ld]", lStatus);
     //	}
-    //  [[NSNotificationCenter defaultCenter] removeObserver:self forKeyPath: kLinphoneCallUpdate];
-//    [[NSNotificationCenter defaultCenter] removeObserver:self forKeyPath:kLinphoneGlobalStateUpdate];
-//    [[NSNotificationCenter defaultCenter] removeObserver:self forKeyPath:kLinphoneConfiguringStateUpdate];
-    
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
     
 }
 

--- a/VATRP/Login/LoginViewController.m
+++ b/VATRP/Login/LoginViewController.m
@@ -210,15 +210,9 @@
     self.textFieldDomain.stringValue = [selectedItem objectForKey:@"domain"];
 }
 
-//-(void)dealloc{
-//    [[NSNotificationCenter defaultCenter] removeObserver:self
-//                                                    name:kLinphoneRegistrationUpdate
-//                                                  object:nil];
-//    
-//    [[NSNotificationCenter defaultCenter] removeObserver:self
-//                                                    name:kLinphoneConfiguringStateUpdate
-//                                                  object:nil];
-//}
+-(void)dealloc{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
 
 - (IBAction)onButtonLogin:(id)sender {
     if (!self.textFieldUsername.stringValue || !self.textFieldUsername.stringValue.length ||


### PR DESCRIPTION
…rash prevention - fixes crash introduced by deallocating LinphoneManager between logins
