### PR TITLE
VATRP:3021: rtt appears properly at the receiving end

### DIFF
--- a/VATRP/Chat/ChatViewController.m
+++ b/VATRP/Chat/ChatViewController.m
@@ -690,7 +690,7 @@ static void chatTable_free_chatrooms(void *data) {
     
 }
 
-- (void)textDidChange:(NSNotification *)aNotification {
+- (void)controlTextDidChange:(NSNotification *)aNotification {
     NSTextField *textField = [aNotification object];
     
     LinphoneCall *currentCall_ = [[CallService sharedInstance] getCurrentCall];

--- a/VATRP/Home/RTT/RTTView.m
+++ b/VATRP/Home/RTT/RTTView.m
@@ -462,7 +462,7 @@ long msgSize; //message length buffer
     }
 }
 
-- (void)controlTextDidChangejhf:(NSNotification *)aNotification
+- (void)controlTextDidChange:(NSNotification *)aNotification
 {
     NSUInteger lastSymbolIndex = self.textFieldMessage.stringValue.length - 1;
     NSString *lastSymbol = [self.textFieldMessage.stringValue substringFromIndex:lastSymbolIndex];


### PR DESCRIPTION
This was broken by the fix for the double characters. method needed renaming.
