### PR TITLE
VATRP-3060: video view is set up only if there is one call. If there …

### DIFF
--- a/VATRP/Home/Video/VideoView.m
+++ b/VATRP/Home/Video/VideoView.m
@@ -582,7 +582,6 @@
         [self update];
         [self.callControllersView setCall:call];
     }
-    // if we have more than one call
 }
 
 - (void)setIncomingCall:(LinphoneCall*)acall {


### PR DESCRIPTION
…are 0, it does not need to have ui elements initialized (and linpheon set accordingly), if there is more than one then it is already set up.
