### PR TITLE
VATRP-3071: If in two calls and the primary call terminates from remo…

### DIFF
--- a/VATRP/Home/Video/VideoView.m
+++ b/VATRP/Home/Video/VideoView.m
@@ -627,6 +627,19 @@
 - (void)hideSecondCallView {
     [self.secondCallView setCall:nil];
     [self.secondCallView setHidden:YES];
+    // verify that the call being held here is the current call
+    LinphoneCall* remainingCall = [[CallService sharedInstance] getCurrentCall];
+    if (remainingCall != call)
+    {
+        // then we need to update the call here and in children that retain a pointer to the call
+        [self setCall:remainingCall];
+        [[CallService sharedInstance] resume:remainingCall];
+    } // otherwise the current call is the remaining call
+    
+    if (call == nil)
+    {
+        NSLog(@"VideoView.hideSecondCallView: The second call view is being hidden and the current call is null.");
+    }
 }
 
 - (void) inCallTick:(NSTimer*)timer {


### PR DESCRIPTION
…te, then update the video view and children to the second call and resume. If the second call ends, just remove it and its view.
