### PR TITLE
VATRP-3071: when a streamsrunning event comes in, make sure that the …

### DIFF
--- a/VATRP/Home/Video/CallControllersView.m
+++ b/VATRP/Home/Video/CallControllersView.m
@@ -112,12 +112,18 @@ BOOL isRTTLocallyEnabled;
 
 -(void)initializeButtonsFromSettings
 {
-    int callCount = [[LinphoneAPI instance] getCurrentNumberOfCalls];
-    if (callCount ==1)
-    { // if it is 0, we do not need to so set up. if it is greater than 1, then we are already set up
+//    int callCount = [[LinphoneAPI instance] getCurrentNumberOfCalls];
+//    if (callCount ==1)
+//    { // if it is 0, we do not need to so set up. if it is greater than 1, then we are already set up
+    if ([[LinphoneAPI instance] callAppearsValid:call])
+    {
         [self updateUIForSpeakerMute:[self.settingsHandler isSpeakerMuted]];
         [self updateUIForMicrophoneMute:[self.settingsHandler isMicrophoneMuted]];
         [self updateUIForEnableVideo:[self.settingsHandler isVideoEnabled]];
+    }
+    else
+    {
+        NSLog(@"CallControllersView.initializeBUttonsFromSettings: trying o initialize but call does not appear to be valid");
     }
 }
 

--- a/VATRP/Home/Video/VideoView.m
+++ b/VATRP/Home/Video/VideoView.m
@@ -299,6 +299,12 @@
             //    LinphoneCallStreamsRunning, /**<The media streams are established and running*/
         case LinphoneCallStreamsRunning:
         {
+            // handle change for call waiting
+            if (call != acall)
+            {
+                // update myself and references
+                [self setCall:acall];
+            }
             SettingsHandler *settingsHandlerInstance = [SettingsHandler settingsHandler];
             [self showSelfViewFromSettings:[settingsHandlerInstance isShowSelfViewEnabled]];
             [self.callerImageView setHidden:true];

--- a/VATRP/Services/CallService.m
+++ b/VATRP/Services/CallService.m
@@ -199,8 +199,10 @@
             if (callToSwapTo != nil)
             {
                 linphone_core_resume_call([LinphoneManager getLc], callToSwapTo);
+                // below should be handled by the call resume - when the streams are runnign again
                 [[[AppDelegate sharedInstance].homeWindowController getHomeViewController].videoView setCall:callToSwapTo];
                 currentCall = callToSwapTo;
+                callToSwapTo = nil; // clear after swapping
             }
             break;
         case LinphoneCallResuming: /**<The call is being resumed by local end*/
@@ -281,7 +283,7 @@
             
             // The streams are set up. Make sure that the initial call settings are handled on call set up here.
             
-            // - there is an issue here. As of 2-9-2016 if we cann enable mic when there is more than one call there is a crash -
+            // - there is an issue here. As of 2-9-2016 if we can enable mic when there is more than one call there is a crash -
             //    linphone is making the settings on each call without checking to see if the audio stream in null. So for now we need
             //    a notion of whether or not this is the first call on the line
             if ([CallService callsCount] < 2)
@@ -295,6 +297,15 @@
                 linphone_core_set_play_level(lc, 100);
                 // tell the rtt window to add observers
                 [[[AppDelegate sharedInstance].homeWindowController getHomeViewController].rttView addInCallObservers];
+            }
+            else
+            {
+                if (currentCall != aCall)
+                {
+                    // handle change for call waiting
+                    // update my pointer
+                    currentCall = aCall;
+                }
             }
             int playLevel = linphone_core_get_play_level(lc);
             int playbackGain = linphone_core_get_playback_gain_db(lc);


### PR DESCRIPTION
…call pointers are updated to the correct call. Update VideoView accodingly, but only after the pointer is updated. Note: at a later date make it so that there is only one call pointer stored in the source (probably in call service) and make all other classes reference that pointer. This will be part of the observer and control flow cleanup.
