### PR TITLE
VATRP-3140: MainWindow and chilrden will now be reused on logout/logi…

### DIFF
--- a/VATRP/AppDelegate.m
+++ b/VATRP/AppDelegate.m
@@ -157,6 +157,10 @@
     {
         self.homeWindowController = [[HomeWindowController alloc] init];
     }
+    else
+    {
+        [self.homeWindowController refreshForNewLogin];
+    }
     [self.homeWindowController showWindow:self];
     if ([[SettingsHandler settingsHandler] isShowPreviewEnabled])
     {
@@ -196,8 +200,10 @@
 }
 
 - (void) closeTabWindow {
+    [self.homeWindowController clearData];
     [self.homeWindowController close];
-    self.homeWindowController = nil;
+    
+    //self.homeWindowController = nil;
 }
 
 - (VideoCallWindowController*) getVideoCallWindow {

--- a/VATRP/Contacts/ContactsView.h
+++ b/VATRP/Contacts/ContactsView.h
@@ -10,4 +10,6 @@
 
 @interface ContactsView : BackgroundedViewController
 - (void) setFrame:(NSRect)frame;
+- (void)refreshContactList;
+-(void)clearData;
 @end

--- a/VATRP/Contacts/ContactsView.m
+++ b/VATRP/Contacts/ContactsView.m
@@ -338,6 +338,12 @@
     self.contactInfos = [self sortListAlphabetically:self.contactInfos];
     [self.tableViewContacts reloadData];
 }
+-(void)clearData
+{
+    [self.contactInfos removeAllObjects];
+    [self.tableViewContacts reloadData];
+}
+
 
 -(NSMutableArray*) sortListAlphabetically:(NSMutableArray*) list{
     NSSortDescriptor *firstNameDescriptor = [[NSSortDescriptor alloc] initWithKey:@"name" ascending:YES];

--- a/VATRP/Home/HomeViewController.h
+++ b/VATRP/Home/HomeViewController.h
@@ -30,6 +30,8 @@
 @property (nonatomic, assign) BOOL isAppFullScreen;
 
 -(void) initializeData;
+-(void)refreshForNewLogin;
+-(void)clearData;
 
 - (ProfileView*) getProfileView;
 - (BOOL) isCurrentTabRecents;

--- a/VATRP/Home/HomeViewController.m
+++ b/VATRP/Home/HomeViewController.m
@@ -180,6 +180,19 @@ bool dialPadIsShown;
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowDidExitFullScreen:) name:NSWindowDidExitFullScreenNotification object:nil];
 }
 
+-(void)refreshForNewLogin
+{
+    [self.recentsView reloadCallLogs];
+    [self.contactsView refreshContactList];
+}
+-(void)clearData
+{
+    [self.recentsView clearData];
+    [self.contactsView clearData];
+    [self.rttView clearData];
+}
+
+
 - (void)didClosedMessagesWindow:(NSNotification*)not {
     [self.dockView clearDockViewMessagesBackgroundColor:YES];
 }

--- a/VATRP/Home/HomeWindowController.h
+++ b/VATRP/Home/HomeWindowController.h
@@ -12,6 +12,9 @@
 @interface HomeWindowController : NSWindowController
 @property (strong) HomeViewController* homeViewController;
 
+-(void)refreshForNewLogin;
+-(void)clearData;
+
 - (HomeViewController*) getHomeViewController;
 
 -(NSPoint) getWindowOrigin;

--- a/VATRP/Home/HomeWindowController.m
+++ b/VATRP/Home/HomeWindowController.m
@@ -53,6 +53,15 @@
 
 }
 
+-(void)refreshForNewLogin
+{
+    [self.homeViewController refreshForNewLogin];
+}
+-(void)clearData
+{
+    [self.homeViewController clearData];
+}
+
 - (HomeViewController*) getHomeViewController {
     return self.homeViewController;
 }

--- a/VATRP/Home/RTT/RTTView.h
+++ b/VATRP/Home/RTT/RTTView.h
@@ -10,6 +10,8 @@
 
 @interface RTTView : BackgroundedViewController
 
+-(void)clearData;
+
 - (void) setCustomFrame:(NSRect)frame;
 
 - (void) updateViewForDisplay;

--- a/VATRP/Home/RTT/RTTView.m
+++ b/VATRP/Home/RTT/RTTView.m
@@ -99,6 +99,11 @@ const NSInteger SIP_SIMPLE=1;
     }
 }
 
+-(void)clearData
+{
+    selectedChatRoom = nil;
+    [self clearMessageList];
+}
 -(void) initializeData
 {
     NSDictionary *attributes = [NSDictionary dictionaryWithObjectsAndKeys:[NSColor whiteColor], NSForegroundColorAttributeName, nil];

--- a/VATRP/Recents/RecentsView.h
+++ b/VATRP/Recents/RecentsView.h
@@ -13,6 +13,7 @@
 
 @property (weak) IBOutlet NSSegmentedControl *callsSegmentControll;
 -(void) initializeData;
+-(void)clearData;
 
 - (void) reloadCallLogs;
 -(void)setFrame:(NSRect)newFrame;

--- a/VATRP/Recents/RecentsView.m
+++ b/VATRP/Recents/RecentsView.m
@@ -160,9 +160,9 @@
             }
             logs = ms_list_next(logs);
         }
+        
+        [self.tableViewRecents reloadData];
     }
-
-    [self.tableViewRecents reloadData];
 }
 
 - (IBAction)onSegmentCallType:(id)sender {
@@ -302,6 +302,11 @@
     [self.callsSegmentControll setFrame:NSMakeRect((frame.size.width - self.callsSegmentControll.frame.size.width)/2, frame.size.height - 30, self.callsSegmentControll.frame.size.width, self.callsSegmentControll.frame.size.height)];
 }
 
+-(void)clearData
+{
+    [callLogs removeAllObjects];
+    [self.tableViewRecents reloadData];
+}
 - (void) dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];


### PR DESCRIPTION
…n instead of recreated. This will eliminate some observer duplications, and it will require good regression testing.

I have refreshed data in the rtt, recents, and contacts panels and it looks like everything else is refreshing appropriately - but am asking for regression testing with this build and for mac testing to kind of reset with this build to give it a thorough go through.
