### PR TITLE
VATRP-3191: Fix crash in SIP simple message. It was acting as both RT…

### DIFF
--- a/VATRP/Chat/ChatViewController.m
+++ b/VATRP/Chat/ChatViewController.m
@@ -610,18 +610,27 @@ static void chatTable_free_chatrooms(void *data) {
                 if (incomingChatMessage) {
                     const char *text_char = linphone_chat_message_get_text(incomingChatMessage);
                     ms_list_remove(self->messageList, incomingChatMessage);
-                    NSString *str_msg = [NSString stringWithUTF8String:text_char];
-                    if ([text isEqualToString:@"\b"]) {
-                        if (str_msg && str_msg.length > 0) {
-                            str_msg = [str_msg substringToIndex:str_msg.length - 1];
-                            self.textViewIncoming.string = str_msg;
+                    if (text_char)
+                    {
+                        // ToDo: Liz E. - there was a crash on this char_text reported as being ""
+                        NSString *str_msg = [NSString stringWithUTF8String:text_char];
+                        if ([text isEqualToString:@"\b"]) {
+                            if (str_msg && str_msg.length > 0) {
+                                str_msg = [str_msg substringToIndex:str_msg.length - 1];
+                                self.textViewIncoming.string = str_msg;
+                            }
+                        } else  {
+                            str_msg = [str_msg stringByAppendingString:text];
+                            self.textViewIncoming.string = [self.textViewIncoming.string stringByAppendingString:text];
                         }
-                    } else {
-                        str_msg = [str_msg stringByAppendingString:text];
-                        self.textViewIncoming.string = [self.textViewIncoming.string stringByAppendingString:text];
-                    }
                     
-                    incomingChatMessage = linphone_chat_room_create_message(selectedChatRoom, [str_msg UTF8String]);
+                        incomingChatMessage = linphone_chat_room_create_message(selectedChatRoom, [str_msg UTF8String]);
+                    }
+                    else
+                    {
+                        bool test = true;
+                        test = false;
+                    }
                 } else {
                     incomingChatMessage = linphone_chat_room_create_message(selectedChatRoom, [text UTF8String]);
                 }
@@ -714,6 +723,7 @@ static void chatTable_free_chatrooms(void *data) {
 }
 
 - (void)controlTextDidChange:(NSNotification *)aNotification {
+    return;
     NSTextField *textField = [aNotification object];
     
     LinphoneCall *currentCall_ = [[CallService sharedInstance] getCurrentCall];
@@ -786,7 +796,7 @@ static void chatTable_free_chatrooms(void *data) {
     
     LinphoneCall *currentCall_ = [[CallService sharedInstance] getCurrentCall];
     
-    if (currentCall_) {
+    if (currentCall_ && outgoingChatMessage) {
         [[ChatService sharedInstance] sendEnter:outgoingChatMessage ChatRoom:selectedChatRoom];
         
         

--- a/VATRP/Services/ChatService.m
+++ b/VATRP/Services/ChatService.m
@@ -92,6 +92,19 @@
     chatWindowController = nil;
 }
 
+// Note: Outgoign may be working properly based on how Windows is behaving. verify display of incoming first
+// the inProgressChatMessage is for an RTT message that the user is currently composing (the enter key has not yet been tapped)
+//-(bool)sendCharacter:(NSString*)message inProgressChatMessage:(LinphoenChatMessage*)inProgressChatMessage
+//{
+//    // verify that the message is valid
+//    LinphoneCall *call = [[CallService sharedInstance] getCurrentCall];
+//
+//    if (!call)
+//        return NO;
+//
+//
+//}
+
 - (BOOL) sendMessagt:(NSString*)message {
     LinphoneCall *call = [[CallService sharedInstance] getCurrentCall];
     
@@ -101,6 +114,7 @@
     LinphoneChatRoom *chat_room = linphone_call_get_chat_room(call);
     
     if (chat_room) {
+        // we shoulkd not be creating a new message with every character. add a send message method for rtt that will accept an existing message.
         LinphoneChatMessage* rtt_message = linphone_chat_room_create_message(chat_room, NULL);
         
         const char* character = [message UTF8String];


### PR DESCRIPTION
…T and SIP SImple Client. Also, Chat Service trying to convert const char\* to NSString even if the string is '\0' (null).

Note: I left the code for a method that I am just returning from in place for the moment. I want to reference it in my next few tickets (RTT) - will do code cleanup with that(those) commits.
