### PR TITLE
VATRP- 3188: Mac/ History Filter seems to be off

### DIFF
--- a/VATRP/Home/DialPad/DialPadView.h
+++ b/VATRP/Home/DialPad/DialPadView.h
@@ -20,4 +20,7 @@
 -(bool)isHidden;
 
 -(void)hideProvidersView:(bool)hide;
+
+@property (weak) IBOutlet NSTextField *textFieldNumber;
+
 @end

--- a/VATRP/Home/DialPad/DialPadView.m
+++ b/VATRP/Home/DialPad/DialPadView.m
@@ -20,7 +20,6 @@
     NSArray *providersArray;
 }
 
-@property (weak) IBOutlet NSTextField *textFieldNumber;
 @property (weak) IBOutlet NSButton *buttonOne;
 @property (weak) IBOutlet NSButton *buttonTwo;
 @property (weak) IBOutlet NSButton *buttonThree;

--- a/VATRP/Home/HomeViewController.m
+++ b/VATRP/Home/HomeViewController.m
@@ -230,6 +230,7 @@ bool dialPadIsShown;
 
 - (void) didClickDockViewRecents
 {
+    [[NSNotificationCenter defaultCenter] postNotificationName:DIALPAD_TEXT_CHANGED object:@""];
     [self.dialPadView hideProvidersView:true];
     [self.viewContainer setFrame:NSMakeRect(0, 81, 310, 567)];
     viewCurrent.hidden = YES;
@@ -277,14 +278,16 @@ bool dialPadIsShown;
     bool dialPadIsHidden = [self.dialPadView isHidden];
     if (dialPadIsHidden)
     {
+        [[NSNotificationCenter defaultCenter] postNotificationName:DIALPAD_TEXT_CHANGED object:self.dialPadView.textFieldNumber.stringValue];
         [self hideDialPad:false];
-        NSRect dialPadFrame = self.dialPadContainer.frame;
+        //NSRect dialPadFrame = self.dialPadContainer.frame;
         [self.viewContainer setFrame:NSMakeRect(0, 351, 310, 297)];
         [viewCurrent setFrame:NSMakeRect(0, 0, self.viewContainer.frame.size.width, self.viewContainer.frame.size.height)];
         [self.dockView selectItemWithDocViewItem:DockViewItemDialpad];
     }
     else
     {
+        [[NSNotificationCenter defaultCenter] postNotificationName:DIALPAD_TEXT_CHANGED object:@""];
         [self hideDialPad:true];
         [self.viewContainer setFrame:NSMakeRect(0, 81, 310, 567)];
         [viewCurrent setFrame:NSMakeRect(0, 0, self.viewContainer.frame.size.width, self.viewContainer.frame.size.height)];


### PR DESCRIPTION
Scenario:
1. Place and receive a few calls, miss a couple of calls to build call history, from Mac 10.10
2. Dial "911" when service is not connected
Notice the call is not completed.
3. Toggle between All Calls and Missed calls
Notice you see only your 911 call and missed calls

Fix: Filter will not have any effect when it is closed(Dial pad window with filter closed).
