### PR TITLE
VATRP- 3148: Quality indicator functionality fix

### DIFF
--- a/VATRP/Home/Video/VideoView.m
+++ b/VATRP/Home/Video/VideoView.m
@@ -694,7 +694,6 @@
         }
         
         int quality = (int)linphone_call_get_current_quality(call);
-        quality = 0;
         
         switch (quality) {
             case 0:


### PR DESCRIPTION
Forgot to remove "quality = 0;"
