### PR TITLE
VATRP- 2129: Mac/ sip spam prevention

### DIFF
--- a/VATRP/linphonerc-factory
+++ b/VATRP/linphonerc-factory
@@ -55,3 +55,6 @@ rate=8000
 channels=1
 enabled=0
 
+sip_port=-1
+sip_tcp_port=-1
+sip_tls_port=-1


### PR DESCRIPTION
as spam prevention, all these three are set to -1 in linphone.rc
sip_port=-1
sip_tcp_port=-1
sip_tls_port=-1
