### PR TITLE
VATRP-3512: Mac: Adaptive Rate false by default, value coming from config …

### DIFF
--- a/VATRP/Services/DefaultConfigurationSettigns/DefaultSettingsManager.m
+++ b/VATRP/Services/DefaultConfigurationSettigns/DefaultSettingsManager.m
@@ -122,7 +122,7 @@ static DefaultSettingsManager *sharedInstance = nil;
     
     [[NSUserDefaults standardUserDefaults] setObject:([dict objectForKey:@"enable_rtt"] != [NSNull null])?[dict objectForKey:@"enable_rtt"]:@"" forKey:@"kREAL_TIME_TEXT_ENABLED"];
     
-    [[NSUserDefaults standardUserDefaults] setObject:([dict objectForKey:@"enable_adaptive_rate"] != [NSNull null])?[dict objectForKey:@"enable_adaptive_rate"]:@"" forKey:@"enable_adaptive_rate_control"];
+//TEMP for VATRP-3512    [[NSUserDefaults standardUserDefaults] setObject:([dict objectForKey:@"enable_adaptive_rate"] != [NSNull null])?[dict objectForKey:@"enable_adaptive_rate"]:@"" forKey:@"enable_adaptive_rate_control"];
     
     [[NSUserDefaults standardUserDefaults] setObject:([dict objectForKey:@"enabled_codecs"] != [NSNull null])?[dict objectForKey:@"enabled_codecs"]:@[@"H.264", @"H.263", @"VP8", @"G.722", @"G.711"] forKey:@"enabled_codecs"];
 //    NSArray* test = [[NSUserDefaults standardUserDefaults] objectForKey:@"enabled_codecs"];

--- a/VATRP/Services/Settings/SettingsHandler.m
+++ b/VATRP/Services/Settings/SettingsHandler.m
@@ -142,7 +142,7 @@
     }
     if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"enable_adaptive_rate_control"] == nil)
     {
-        [[NSUserDefaults standardUserDefaults] setObject:@"true" forKey:@"enable_adaptive_rate_control"];
+        [[NSUserDefaults standardUserDefaults] setObject:@"false" forKey:@"enable_adaptive_rate_control"];
     }
     if (force || [[NSUserDefaults standardUserDefaults]objectForKey:@"enabled_codecs"] == nil)
     {


### PR DESCRIPTION
…server ignoered for now with TEMP VATRP-3512 comment
