### PR TITLE
Fix the empty UserID for userLogin so that Purple works again

### DIFF
--- a/VATRP/Login/LoginViewController.m
+++ b/VATRP/Login/LoginViewController.m
@@ -414,7 +414,7 @@
   
     
         [[RegistrationService sharedInstance] registerWithUsername:loginAccount.username
-                                                            UserID:@loginAccount.userID
+                                                            UserID:loginAccount.userID
                                                           password:loginAccount.password
                                                             domain:loginAccount.domain
                                                          transport:loginAccount.transport


### PR DESCRIPTION
This should undo one of the small unfortunate changes made during the VATRP-2888 update
