### PR TITLE
Vatrp-3754:Mac: In same call, open RTT and type. Close and re-open RTT, the conversation history will be lost

### DIFF
--- a/VATRP/Home/RTT/RTTView.m
+++ b/VATRP/Home/RTT/RTTView.m
@@ -207,7 +207,7 @@ const NSInteger SIP_SIMPLE=1;
     if (![self getCurrentChatRoom])
         return;
     
-//    messageList = linphone_chat_room_get_history([self getCurrentChatRoom], 1);
+    messageList = linphone_chat_room_get_history([self getCurrentChatRoom], 0);
 }
 
 - (void)clearMessageList {
@@ -622,6 +622,9 @@ long msgSize; //message length buffer
             LinphoneChatRoom* chatRoom = [self getCurrentChatRoom];
             [[ChatService sharedInstance] sendEnter:outgoingChatMessage ChatRoom:chatRoom];
 
+            // we must ref & unref message because in case of error, it will be destroy otherwise
+            linphone_chat_room_send_chat_message(chatRoom, linphone_chat_message_ref(outgoingChatMessage));
+
             self->messageList = ms_list_append(self->messageList, outgoingChatMessage);
             
             [self.tableViewContent reloadData];
@@ -664,8 +667,8 @@ long msgSize; //message length buffer
     if (externalUrl) {
         linphone_chat_message_set_external_body_url(msg, [[externalUrl absoluteString] UTF8String]);
     }
-    
-    linphone_chat_room_send_message2(room, msg, message_status, (__bridge void *)(self));
+
+    linphone_chat_room_send_chat_message(room, msg);
     
     if (internalUrl) {
         // internal url is saved in the appdata for display and later save

--- a/VATRP/LinphoneManager/LinphoneManager.m
+++ b/VATRP/LinphoneManager/LinphoneManager.m
@@ -765,9 +765,11 @@ static void linphone_info_received (LinphoneCore *lc, LinphoneCall *call, const 
     LinphoneCall* currentCall = linphone_core_get_current_call(theLinphoneCore);
     if (call == currentCall) {
         const char* videoModeStatus = linphone_info_message_get_header(msg, "action");
-        NSDictionary *dict = @{@"videoModeStatus": [NSString stringWithUTF8String:videoModeStatus]
-                               };
-        [[NSNotificationCenter defaultCenter] postNotificationName:kLinphoneVideModeUpdate object:self userInfo:dict];
+        if (videoModeStatus) {
+            NSDictionary *dict = @{@"videoModeStatus": [NSString stringWithUTF8String:videoModeStatus]
+                                   };
+            [[NSNotificationCenter defaultCenter] postNotificationName:kLinphoneVideModeUpdate object:self userInfo:dict];
+        }
     }
 }
 

--- a/VATRP/Services/CallService.m
+++ b/VATRP/Services/CallService.m
@@ -578,8 +578,6 @@
     {
         NSString* address;
         const LinphoneAddress* addr = linphone_call_get_remote_address(call);
-        char * remoteAddress = linphone_call_get_remote_address_as_string(call);
-        NSString  *sipURI = [NSString stringWithUTF8String:remoteAddress];
         if (addr != NULL) {
             BOOL useLinphoneAddress = true;
             // contact name


### PR DESCRIPTION
Corrected functionality to load chat history.
