### PR TITLE
VATRP-3881: Fix Port field is empty messages

### DIFF
--- a/VATRP/Settings/AccountsViewController.m
+++ b/VATRP/Settings/AccountsViewController.m
@@ -243,17 +243,17 @@
         error = YES;
         errorString = @"Port field is required";
     }
-    
+   /*
     if ([self.textCardDavRealmName.stringValue isEqual:@""] && !error) {
         error = YES;
-        errorString = @"Port field is required";
+        errorString = @"CardDAV RealmName field is required";
     }
     
     if ([self.textCardDavServerPath.stringValue isEqual:@""] && !error) {
         error = YES;
-        errorString = @"Port field is required";
+        errorString = @"CardDAV ServerPath field is required";
     }
-    
+    */
     if (error) {
         NSAlert *alert = [[NSAlert alloc] init];
         [alert addButtonWithTitle:@"OK"];


### PR DESCRIPTION
Comment out the CardDAV RealmName and ServerPath empty string checks as they were cloned from the Port field is empty check are are not enforcing settings in any real way.
